### PR TITLE
Add zod as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   ],
   "author": "Matt Pocock",
   "license": "MIT",
+  "peerDependencies": {
+    "zod": "^3.20.2"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.26.0",
     "tsup": "^6.5.0",


### PR DESCRIPTION
First of all, even if it is only a few lines of code, I really like the idea of this lib. and I think it's amazing!

Since this wonderful library is directly dependent on zod, it is best to force users to have zod installed to avoid problems 😄 

Ty!