### PR TITLE
Ensure readme example has no typescript errors

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ const fetchWithZod = createZodFetcher();
 fetchWithZod(
   // The schema you want to validate with
   z.object({
-    hello: "world",
+    hello: z.literal("world"),
   }),
   // Any parameters you would usually pass to fetch
   "/my-api",


### PR DESCRIPTION
I was getting the following message with the example in the README: 

`Type 'string' is not assignable to type 'ZodTypeAny'.`

This change fixed it.

For reference here are my zod and typescript versions but I think literals must be represented by `z.literal() (https://github.com/colinhacks/zod#literals):
```
"zod": "3.19.1",
"zod-fetch": "0.1.0"
"typescript": "4.5.3"
```